### PR TITLE
Add history subroutine implementation

### DIFF
--- a/lib/Minion/Backend/Redis.pm
+++ b/lib/Minion/Backend/Redis.pm
@@ -802,8 +802,6 @@ is required to use this backend.
 
 This is a slightly hackish modification of the original code by L<Dan Book|https://github.com/Grinnz/Minion-Backend-Redis> to use L<Mojo::Redis> instead of L<Mojo::Redis2>.
 
-Due to the original code being written against an older Minion version, "history" is currently unimplemented.
-
 =head1 PERFORMANCE
 
 You can run examples/minion_bench.pl to get some performance metrics.  


### PR DESCRIPTION
Added functionality to history function
Removed unimplemented warning from docs

Code formatting changed, diff is all over the place. 

Changed are:
line 14: + use Time::Piece;

lines 124-149 

```
sub history {
    my $self = shift;
    my $now = localtime();
    my $redis = $self->redis->db;
    my $res = $redis->keys("minion.job.*");

    my $history;
    foreach my $id (@$res) {
        my $info = $self->redis->db->hgetall($id);
        my $t = localtime($info->{finished});
        my $diff = $now - $t;
        next if ($diff->minutes > 1440);

        my $day_hour = Time::Piece->strptime($t->ymd . " " . $t->hour, "%Y-%m-%d %H");
        $history->{$day_hour->epoch} //= { epoch => $day_hour->epoch, finished_jobs => 0, failed_jobs => 0 };
        $history->{$day_hour->epoch}->{finished_jobs}++ if $info->{state} eq 'finished';
        $history->{$day_hour->epoch}->{failed_jobs}++ if $info->{state} eq 'failed';
    }

    my @daily_ordered;
    for (sort keys %{$history}) {
        push(@daily_ordered, $history->{$_});
    }

    return { daily => \@daily_ordered };
}
```